### PR TITLE
Added support for sql functions on DEFAULT option in schema.rb

### DIFF
--- a/lib/active_record/connection_adapters/redshift/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_definitions.rb
@@ -90,7 +90,7 @@ module ActiveRecord
       end
 
       class ColumnDefinition < ActiveRecord::ConnectionAdapters::ColumnDefinition
-        attr_accessor :array
+        attr_accessor :array, :default_function
       end
 
       class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
@@ -134,6 +134,7 @@ module ActiveRecord
         def new_column_definition(name, type, options) # :nodoc:
           column = super
           column.array = options[:array]
+          column.default_function = options[:default_function]
           column
         end
 

--- a/lib/active_record/connection_adapters/redshift/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_statements.rb
@@ -24,6 +24,10 @@ module ActiveRecord
           else
             super
           end
+          if options[:default_function] || column.try(:default_function)
+            sql << " DEFAULT #{column.default_function}"
+          end
+          sql
         end
 
         def type_for_column(column)

--- a/lib/active_record/connection_adapters/redshift_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_adapter.rb
@@ -130,13 +130,16 @@ module ActiveRecord
       def prepare_column_options(column, types) # :nodoc:
         spec = super
         spec[:array] = 'true' if column.respond_to?(:array) && column.array
-        spec[:default] = "\"#{column.default_function}\"" if column.default_function
+        if column.default_function
+          spec.delete(:default) # lets remove any DEFAULT that might be set
+          spec[:default_function] = "\"#{column.default_function}\""
+        end
         spec
       end
 
       # Adds +:array+ as a valid migration key
       def migration_keys
-        super + [:array]
+        super + [:array, :default_function]
       end
 
       # Returns +true+, since this connection adapter supports prepared statement


### PR DESCRIPTION
Rails migrations don't support setting sql functions on the `:default` option in the schema.rb (used by db:test:prepare rake task) but we need some columns on our redshift to have a default GETDATE() on the created_at and updated_at fields.

Postgres activerecord driver had already a basic support for detecting functions on default options but wasn't capable of generating the correct sql for them.

This PR fixes that. It adds a new option to the migrations' column definition that can be used to set functions. It's called `:default_function` and is is only used to place sql functions.
A schema dump of a field with a default function will look like:
`t.column :timestamp, default_function: 'getdate()'`

Relates to followanalytics/fa-issues#1735


